### PR TITLE
fix(components): adjust the disabled button display

### DIFF
--- a/packages/components/button/src/index.vue
+++ b/packages/components/button/src/index.vue
@@ -26,12 +26,13 @@ const sizeMap = {
     :is="to ? 'a' : 'button'"
     v-bind="to ? { href: to } : {}"
     :disabled="disabled"
-    class="o-transition o-button-base o-button-hover o-button-active"
+    :aria-disabled="disabled"
+    class="o-button-base"
     :class="[
       light ? 'o-button-light' : '',
       text ? 'o-button-text' : '',
       sizeMap[size],
-      disabled ? 'o-disabled' : '',
+      disabled ? 'o-disabled' : 'o-transition o-button-hover o-button-active',
     ]"
   >
     <slot name="icon">

--- a/packages/preset/src/index.ts
+++ b/packages/preset/src/index.ts
@@ -36,9 +36,8 @@ export function presetOnu(): Preset {
         'color': 'white !important',
       }],
       ['o-disabled', {
-        'opacity': 0.4,
-        'pointer-events': 'none',
-        'cursor': 'not-allowed',
+        opacity: 0.4,
+        cursor: 'not-allowed',
       }],
     ],
     variants: [


### PR DESCRIPTION
When the button is in the disabled state, the cursor: not-allowed is disabled by the CSS pointer-events: none. When the mouse hovers over the disabled element, the appearance of the cursor does not change.