### PR TITLE
Add logic to button group

### DIFF
--- a/packages/components/button/src/button-group.ts
+++ b/packages/components/button/src/button-group.ts
@@ -4,6 +4,7 @@ import { buttonProps } from './button'
 export const buttonGroupProps = {
   type: buttonProps.type,
   size: buttonProps.size,
+  multiple: Boolean,
   spacer: Boolean,
 }
 

--- a/packages/components/button/src/button-group.ts
+++ b/packages/components/button/src/button-group.ts
@@ -1,9 +1,13 @@
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, PropType } from 'vue'
 import { buttonProps } from './button'
 
 export const buttonGroupProps = {
   type: buttonProps.type,
   size: buttonProps.size,
+  modelValue: {
+    type: [Number, String, Array] as PropType<number | string | number[] | string[]>,
+    default: '',
+  },
   multiple: Boolean,
   spacer: Boolean,
 }

--- a/packages/components/button/src/button-group.vue
+++ b/packages/components/button/src/button-group.vue
@@ -1,8 +1,29 @@
 <script setup lang="ts" name="OButtonGroup">
+import type { VNode } from 'vue'
+import { computed, h, onMounted, reactive, useSlots } from 'vue'
+
 import { buttonGroupProps } from './button-group'
 import { buttonGroupContextKey } from './constants'
 
+import OButton from './button.vue'
+
 const props = defineProps(buttonGroupProps)
+const emit = defineEmits(['update:modelValue'])
+const slots = useSlots()
+
+const state = reactive({
+  buttonsState: [] as boolean[],
+  isFirstLoad: true,
+})
+
+const selectedValue = computed({
+  get(): number | string | number[] | string[] | undefined {
+    return props.modelValue
+  },
+  set(val: number | string | number[] | string[] | undefined) {
+    emit('update:modelValue', val)
+  },
+})
 
 provide(
   buttonGroupContextKey,
@@ -11,12 +32,98 @@ provide(
     type: toRef(props, 'type'),
   }),
 )
+
+const fillState = (amountOfButtons: number) => {
+  for (let index = 0; index < amountOfButtons; index++) {
+    if (!props.modelValue) {
+      state.buttonsState.push(false)
+    }
+    else {
+      index === +props?.modelValue
+        ? state.buttonsState.push(true)
+        : state.buttonsState.push(false)
+    }
+  }
+}
+
+const setSelectedValue = (value: string | number) => {
+  if (
+    typeof selectedValue.value === 'string'
+    || typeof selectedValue.value === 'number'
+    || typeof selectedValue.value === 'undefined'
+  ) {
+    selectedValue.value = value
+  }
+  else {
+    const localSelectedValue = [...selectedValue.value]
+
+    if (localSelectedValue.includes(value))
+      localSelectedValue.splice(localSelectedValue.indexOf(value), 1)
+
+    else
+      localSelectedValue.push(value)
+
+    selectedValue.value = localSelectedValue as string[]
+  }
+}
+
+const activateButton = (index: number) => {
+  if (props.multiple) {
+    state.buttonsState.splice(index, 1, !state.buttonsState[index])
+    return
+  }
+
+  state.buttonsState.forEach((_, stateIndex) => {
+    state.buttonsState.splice(stateIndex, 1, false)
+  })
+  state.buttonsState.splice(index, 1, true)
+}
+
+const genButton = (slotButton: VNode, index: number): VNode => {
+  return h(
+    OButton,
+    {
+      onClick: (e, value) => {
+        e.preventDefault()
+
+        setSelectedValue(value || index)
+
+        activateButton(index)
+      },
+      active: state.buttonsState[index],
+      value: slotButton?.props?.value ?? index,
+      class: {
+        'hover:bg-accent-darken-1': true,
+        'active:bg-accent-darken-2': true,
+      },
+    },
+    slotButton.children as string,
+  )
+}
+
+const genContent = () => {
+  if (slots.default && !slots.default())
+    return []
+
+  return slots.default && slots.default().map((slotButton, index) => {
+    return genButton(slotButton, index)
+  })
+}
+
+onMounted(() => {
+  slots && fillState((slots.default && slots.default()?.length) ?? 0)
+
+  if (props.multiple)
+    selectedValue.value = []
+})
+
+const render = () => {
+  return h('div', { class: ['o-button-group o-button-group-clearfix inline-block align-middle o-button-group-children', { spacer: !!props.spacer }] }, genContent())
+}
 </script>
 
 <template>
-  <div class="o-button-group o-button-group-clearfix inline-block align-middle o-button-group-children" :class="[spacer && 'spacer']">
-    <slot />
-  </div>
+  <render />
 </template>
 
 <style scope>

--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -18,6 +18,10 @@ export const buttonProps = {
   disabled: Boolean,
   loading: Boolean,
   icon: String,
+  value: {
+    type: [String, Number, undefined] as PropType<string | number | undefined>,
+    default: undefined,
+  },
 }
 
 export type OButtonProps = ExtractPropTypes<typeof buttonProps>

--- a/packages/components/button/src/button.vue
+++ b/packages/components/button/src/button.vue
@@ -3,6 +3,9 @@ import { buttonProps } from './button'
 import { buttonGroupContextKey } from './constants'
 
 const props = defineProps(buttonProps)
+
+const emit = defineEmits(['click'])
+
 const buttonGroupContext = inject(buttonGroupContextKey, undefined)
 
 // todo: The property should follow this inheritance rule: component props > custom group rule > formItem props > form props > global size > default
@@ -17,6 +20,10 @@ const defaultText = computed(() => _type.value === 'default' && props.text)
 const slots = useSlots()
 const onlyIcon = computed(() => (slots.icon || props.icon) && !slots.default)
 const binds = Object.assign({}, useAttrs(), props.to ? { href: props.to } : {})
+
+const onClick = (event) => {
+  emit('click', event, props.value)
+}
 </script>
 
 <template>
@@ -39,6 +46,7 @@ const binds = Object.assign({}, useAttrs(), props.to ? { href: props.to } : {})
       defaultText ? 'o-button-defaultText' : '',
       dashed && 'border-dashed',
     ]"
+    @click="onClick"
   >
     <div v-if="loading" i-carbon-circle-dash animate-spin />
     <slot v-else name="icon">

--- a/test/components/button-group.test.ts
+++ b/test/components/button-group.test.ts
@@ -17,12 +17,27 @@ describe('o-button-group', () => {
       slots: {
         default: buttons,
       },
-      propsData: {
-        value: 'test-button-group',
-      },
     })
 
     const renderedButtons = wrapper.findAllComponents(OButton)
     expect(renderedButtons.length).toBe(buttons.length)
+  })
+  test('updates v-model value to the correct button clicked', async () => {
+    const buttons = [1, 2, 3].map(index => shallowMount(OButton, { props: { value: index } }))
+
+    const wrapper = mount(OButtonGroup, {
+      slots: {
+        default: buttons,
+      },
+      props: {
+        'modelValue': '1',
+        'onUpdate:modelValue': (value: string) => wrapper.setProps({ modelValue: value }),
+      },
+
+    })
+
+    await wrapper.find('button:nth-child(3)').trigger('click')
+
+    expect(wrapper.props('modelValue')).toBe(2)
   })
 })

--- a/test/components/button-group.test.ts
+++ b/test/components/button-group.test.ts
@@ -10,4 +10,19 @@ describe('o-button-group', () => {
 
     expect(wrapper.html()).toContain('Test')
   })
+  test('render the correct amount of buttons', () => {
+    const buttons = [1, 2, 3].map(() => OButton)
+
+    const wrapper = mount(OButtonGroup, {
+      slots: {
+        default: buttons,
+      },
+      propsData: {
+        value: 'test-button-group',
+      },
+    })
+
+    const renderedButtons = wrapper.findAllComponents(OButton)
+    expect(renderedButtons.length).toBe(buttons.length)
+  })
 })

--- a/test/components/button-group.test.ts
+++ b/test/components/button-group.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest'
+import { mount, shallowMount } from '@vue/test-utils'
+
+import { OButton, OButtonGroup } from '@onu-ui/components'
+
+describe('o-button-group', () => {
+  test('o-button-group render test', () => {
+    const buttonWrapper = shallowMount(OButton, { slots: { default: 'Test' } })
+    const wrapper = mount(OButtonGroup, { slots: { default: () => buttonWrapper.html() } })
+
+    expect(wrapper.html()).toContain('Test')
+  })
+})


### PR DESCRIPTION
As I looked into your code, I noticed that the button group component is only aesthetic. I think it's helpful that the button group component has v-model support adding double to the selected button. 

I did it in a way that resembles Vuetify's button group API.

My changes don't touch styles. Only the logic.