### PR TITLE
fix(docs): replace images placeholder provider

### DIFF
--- a/docs/example/empty/image.vue
+++ b/docs/example/empty/image.vue
@@ -1,3 +1,3 @@
 <template>
-  <o-empty image="https://placeimg.com/400/225/arch" description="This is a Description" />
+  <o-empty image="https://placehold.co/600x400" description="This is a Description" />
 </template>

--- a/docs/example/empty/imgSize.vue
+++ b/docs/example/empty/imgSize.vue
@@ -1,3 +1,3 @@
 <template>
-  <o-empty image="https://placeimg.com/400/225/arch" :img-size="300" />
+  <o-empty image="https://placehold.co/600x400" :img-size="300" />
 </template>


### PR DESCRIPTION
Hello 
The website: https://placeimg.com used to provide placeholder images for the doc stopped working

the files updates:

- docs/example/empty/imgSize.vue
- docs/example/empty/images.vue

<img width="1046" alt="image" src="https://github.com/onu-ui/onu-ui/assets/11523791/286d9961-059d-47fe-b0de-36454ce0685b">
