### PR TITLE
refactor: use macro define component name

### DIFF
--- a/docs/.vitepress/components/demo-block/src/index.vue
+++ b/docs/.vitepress/components/demo-block/src/index.vue
@@ -1,9 +1,12 @@
-<script lang='ts' setup name="demo-block">
+<script lang='ts' setup>
 import { computed } from 'vue'
 import { isClient, useClipboard, useToggle } from '@vueuse/core'
 import { usePlayground } from './playground'
 import { demoProps } from './index'
 
+defineOptions({
+  name: 'ODemoBlock',
+})
 const props = defineProps(demoProps)
 
 const decodedHighlightedCode = computed(() =>

--- a/packages/components/checkbox/src/index.vue
+++ b/packages/components/checkbox/src/index.vue
@@ -1,8 +1,11 @@
-<script lang="ts" setup name="OCheckbox">
+<script lang="ts" setup>
 import { hash } from '@onu-ui/utils'
 import type { Ref } from 'vue'
 import { checkBoxProps } from './props'
 
+defineOptions({
+  name: 'OCheckbox',
+})
 const props = defineProps(checkBoxProps)
 
 const emits = defineEmits(['update:modelValue', 'change'])

--- a/packages/components/collapse/src/collapse.vue
+++ b/packages/components/collapse/src/collapse.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts" name="OCollapse">
+<script setup lang="ts">
 // TODO test
 import { provide, ref, watch } from 'vue'
 import type {
@@ -11,6 +11,9 @@ import {
   collapseProps,
 } from './props'
 
+defineOptions({
+  name: 'OCollapse',
+})
 const props = defineProps(collapseProps)
 const emit = defineEmits(collapseEmits)
 const activeNames = ref(props.expandedNames)

--- a/packages/components/collapse/src/collapseItem.vue
+++ b/packages/components/collapse/src/collapseItem.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts" name="OCollapseItem">
+<script setup lang="ts">
 // TODO test
 import { computed, inject } from 'vue'
 
@@ -6,6 +6,9 @@ import OIcon from '../../icon/src/index.vue'
 import type { RendererElement } from './props'
 import { collapseContextKey, collapseItemProps } from './props'
 
+defineOptions({
+  name: 'OCollapseItem',
+})
 const props = defineProps(collapseItemProps)
 const collapse = inject(collapseContextKey)
 

--- a/packages/components/empty/src/index.vue
+++ b/packages/components/empty/src/index.vue
@@ -1,8 +1,11 @@
-<script setup lang='ts' name="OEmpty">
+<script setup lang='ts'>
 import { useLocale } from '@onu-ui/utils'
 import type { CSSProperties } from 'vue'
 import { emptyProps } from './props'
 
+defineOptions({
+  name: 'OEmpty',
+})
 const props = defineProps(emptyProps)
 
 const { t } = useLocale()

--- a/packages/components/icon/src/index.vue
+++ b/packages/components/icon/src/index.vue
@@ -1,6 +1,9 @@
-<script lang='ts' setup name="OIcon">
+<script lang='ts' setup>
 import { iconProps } from './props'
 
+defineOptions({
+  name: 'OIcon',
+})
 defineProps(iconProps)
 </script>
 

--- a/packages/components/link/src/link.vue
+++ b/packages/components/link/src/link.vue
@@ -1,5 +1,9 @@
-<script setup lang="ts" name="OLink">
+<script setup lang="ts">
 import { linkEmits, linkProps } from './link'
+
+defineOptions({
+  name: 'OLink',
+})
 
 const props = defineProps(linkProps)
 const emit = defineEmits(linkEmits)

--- a/packages/components/message/src/index.vue
+++ b/packages/components/message/src/index.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts" name="OMessage">
+<script setup lang="ts">
 import type { CSSProperties } from 'vue'
 import { computed, onMounted, ref } from 'vue'
 import { useResizeObserver, useTimeoutFn } from '@vueuse/core'
@@ -6,6 +6,9 @@ import OIcon from '../../icon/src/index.vue'
 import { messageEmits, messageProps } from './type'
 import { useOffset } from './instance'
 
+defineOptions({
+  name: 'OMessage',
+})
 const props = defineProps(messageProps)
 defineEmits(messageEmits)
 

--- a/packages/components/popup/src/index.vue
+++ b/packages/components/popup/src/index.vue
@@ -1,7 +1,10 @@
-<script setup lang='ts' name="OPopup">
+<script setup lang='ts'>
 import OTrigger from '../../trigger/src/index'
 import { popupEmits, popupProps } from './props'
 
+defineOptions({
+  name: 'OPopup',
+})
 const props = defineProps(popupProps)
 const emit = defineEmits(popupEmits)
 

--- a/packages/components/progress/src/progress.vue
+++ b/packages/components/progress/src/progress.vue
@@ -1,9 +1,12 @@
-<script setup lang="ts" name="OProgress">
+<script setup lang="ts">
 import { isFunction, isString } from '@onu-ui/utils'
 import type { CSSProperties } from 'vue'
 import type { ProgressColor } from './progress'
 import { SIZE_MAP, STATUS_COLOR_MAP, STATUS_MAP, TYPE_MAP, progressProps } from './progress'
 
+defineOptions({
+  name: 'OProgress',
+})
 const props = defineProps(progressProps)
 
 const stripedStyle = {

--- a/packages/components/radio/src/radio-group.vue
+++ b/packages/components/radio/src/radio-group.vue
@@ -1,8 +1,11 @@
-<script setup lang="ts" name="ORadioGroup">
+<script setup lang="ts">
 import { radioGroupKey } from './constants'
 import type { ORadioGroupProps } from './radio-group'
 import { radioGroupEmits, radioGroupProps } from './radio-group'
 
+defineOptions({
+  name: 'ORadioGroup',
+})
 const props = defineProps(radioGroupProps)
 const emit = defineEmits(radioGroupEmits)
 const radioGroupRef = ref<HTMLDivElement>()

--- a/packages/components/radio/src/radio.vue
+++ b/packages/components/radio/src/radio.vue
@@ -1,7 +1,10 @@
-<script setup lang="ts" name="ORadio">
+<script setup lang="ts">
 import { radioEmits, radioProps } from './radio'
 import { useRadio } from './use-radio'
 
+defineOptions({
+  name: 'ORadio',
+})
 const props = defineProps(radioProps)
 const emit = defineEmits(radioEmits)
 

--- a/packages/components/rate/src/index.vue
+++ b/packages/components/rate/src/index.vue
@@ -1,8 +1,11 @@
-<script lang="ts" setup name="ORate">
+<script lang="ts" setup>
 import { computed } from 'vue'
 import OIcon from '../../icon/src/index.vue'
 import { rateProps } from './props'
 
+defineOptions({
+  name: 'ORate',
+})
 const props = defineProps(rateProps)
 const emits = defineEmits(['update:modelValue', 'change'])
 

--- a/packages/components/switch/src/index.vue
+++ b/packages/components/switch/src/index.vue
@@ -1,7 +1,10 @@
-<script lang="ts" setup name="OSwitch">
+<script lang="ts" setup>
 import type { Ref } from 'vue'
 import { switchProps } from './props'
 
+defineOptions({
+  name: 'OSwitch',
+})
 const props = defineProps(switchProps)
 
 const emits = defineEmits(['update:modelValue', 'change'])

--- a/packages/components/tag/src/index.vue
+++ b/packages/components/tag/src/index.vue
@@ -1,7 +1,10 @@
-<script lang='ts' setup name="OTag">
+<script lang='ts' setup>
 import OIcon from '../../icon/src/index.vue'
 import { tagEmits, tagProps } from './props'
 
+defineOptions({
+  name: 'OTag',
+})
 defineProps(tagProps)
 const emits = defineEmits(tagEmits)
 

--- a/packages/components/text/src/text.vue
+++ b/packages/components/text/src/text.vue
@@ -1,7 +1,10 @@
-<script setup lang="ts" name="OText">
+<script setup lang="ts">
 import type { CSSProperties } from 'vue'
 import { fontMap, textProps } from './text'
 
+defineOptions({
+  name: 'OText',
+})
 const props = defineProps(textProps)
 
 // todo: The size property should follow this inheritance rule: component props > custom group rule > formItem props > form props > global size > default

--- a/packages/components/tooltip/src/index.vue
+++ b/packages/components/tooltip/src/index.vue
@@ -1,8 +1,11 @@
-<script setup lang='ts' name="OToolTip">
+<script setup lang='ts'>
 import type { CSSProperties } from 'vue'
 import OTrigger from '../../trigger/src/index'
 import { toolTipEmits, toolTipProps } from './props'
 
+defineOptions({
+  name: 'OToolTip',
+})
 const props = defineProps(toolTipProps)
 const emit = defineEmits(toolTipEmits)
 


### PR DESCRIPTION
This PR refactors some components using macro defined component names.
It can resolve the VitePress lookup component in the demo preview and fixed issue #200 