### PR TITLE
docs: maintain border style consistent with vitepress

### DIFF
--- a/docs/.vitepress/theme/override.css
+++ b/docs/.vitepress/theme/override.css
@@ -11,14 +11,13 @@ body {
   --vp-c-brand-2: hsl(var(--onu-color-600) / 1);
   --vp-button-brand-bg: hsl(var(--onu-color-DEFAULT) / 1);
   --vp-button-brand-hover-bg: hsl(var(--onu-color-600) / 1);
-  --vp-c-gutter: hsl(var(--onu-color-100) / 1);
+  --vp-c-gutter: var(--vp-c-divider);
 
   --vp-nav-bg-color: transparent;
 }
 
 .dark {
   --vp-c-brand-2: hsl(var(--onu-color-400) / 1);
-  --vp-c-gutter: hsl(var(--onu-color-900) / 1);
 }
 
 


### PR DESCRIPTION
before:
<img width="977" alt="image" src="https://github.com/user-attachments/assets/1209e11b-39fb-452c-9ac2-d1e8971d5249">

after:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/20cbd50f-7362-4f48-ab72-6a1a636dde91">
